### PR TITLE
Update Context.cs

### DIFF
--- a/Runtime/Core/Context/Context.cs
+++ b/Runtime/Core/Context/Context.cs
@@ -20,6 +20,8 @@ namespace Tarject.Runtime.Core.Context
         private OptimizedList<ILateUpdatable> _lateUpdatables;
         private OptimizedList<ILateDisposable> _lateDisposables;
 
+        private bool _initialized = false;
+
         protected virtual void Awake()
         {
             SetParentContainer();
@@ -31,6 +33,8 @@ namespace Tarject.Runtime.Core.Context
             GetTriggerableInterfaces();
 
             _initializables.ForEach(x => x.Initialize());
+
+            _initialized = true;
         }
 
         protected abstract void SetParentContainer();
@@ -59,21 +63,25 @@ namespace Tarject.Runtime.Core.Context
 
         private void Update()
         {
+            if (!_initialized) return;
             _updatables.ForEach(x => x.Update());
         }
 
         private void FixedUpdate()
         {
+            if (!_initialized) return;
             _fixedUpdatables.ForEach(x => x.FixedUpdate());
         }
 
         private void LateUpdate()
         {
+            if (!_initialized) return;
             _lateUpdatables.ForEach(x => x.LateUpdate());
         }
 
         protected virtual void OnDestroy()
         {
+            if (!_initialized) return;
             _lateDisposables.ForEach(x => x.LateDispose());
         }
     }

--- a/Runtime/Core/Context/Context.cs
+++ b/Runtime/Core/Context/Context.cs
@@ -32,7 +32,6 @@ namespace Tarject.Runtime.Core.Context
 
             _initializables.ForEach(x => x.Initialize());
 
-            _initialized = true;
         }
 
         protected abstract void SetParentContainer();

--- a/Runtime/Core/Context/Context.cs
+++ b/Runtime/Core/Context/Context.cs
@@ -20,8 +20,6 @@ namespace Tarject.Runtime.Core.Context
         private OptimizedList<ILateUpdatable> _lateUpdatables;
         private OptimizedList<ILateDisposable> _lateDisposables;
 
-        private bool _initialized = false;
-
         protected virtual void Awake()
         {
             SetParentContainer();
@@ -63,26 +61,22 @@ namespace Tarject.Runtime.Core.Context
 
         private void Update()
         {
-            if (!_initialized) return;
-            _updatables.ForEach(x => x.Update());
+            _updatables?.ForEach(x => x.Update());
         }
 
         private void FixedUpdate()
         {
-            if (!_initialized) return;
-            _fixedUpdatables.ForEach(x => x.FixedUpdate());
+            _fixedUpdatables?.ForEach(x => x.FixedUpdate());
         }
 
         private void LateUpdate()
         {
-            if (!_initialized) return;
-            _lateUpdatables.ForEach(x => x.LateUpdate());
+            _lateUpdatables?.ForEach(x => x.LateUpdate());
         }
 
         protected virtual void OnDestroy()
         {
-            if (!_initialized) return;
-            _lateDisposables.ForEach(x => x.LateDispose());
+            _lateDisposables?.ForEach(x => x.LateDispose());
         }
     }
 }


### PR DESCRIPTION
Add _initialized field to Context class for init tracking

Introduce a private boolean field `_initialized` in the `Context` class to track initialization status. Set `_initialized` to `false` by default and update it to `true` after initialization in the `Awake` method. Modify `Update`, `FixedUpdate`, `LateUpdate`, and `OnDestroy` methods to check `_initialized` and return early if initialization is not complete. This prevents update and dispose logic from running prematurely.