### PR TITLE
Fix: Scene-Specific Container Injection for Instantiator & Factory

### DIFF
--- a/Runtime/Core/Instantiator/StaticInstantiator.cs
+++ b/Runtime/Core/Instantiator/StaticInstantiator.cs
@@ -26,7 +26,11 @@ namespace Tarject.Runtime.Core.Instantiator
             }
 
             T createdObject = Object.Instantiate(prefab, tempParent);
-            container ??= createdObject.gameObject.scene.GetSceneContainer();
+            
+            container ??= parent == null 
+                ? createdObject.gameObject.scene.GetSceneContainer()
+                : parent.gameObject.scene.GetSceneContainer();
+            
             createdObject.InjectToFields(container);
 
             if (createdObject is MonoInjecter monoInjecter)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.tariksavas.tarject",
-    "version": "1.0.12",
+    "version": "1.0.13",
     "displayName": "Tarject",
     "description": "This is a Dependency Injection Framework for Unity",
     "unity": "2019.1",


### PR DESCRIPTION
This update resolves an issue where objects created via Instantiator or Factory were not receiving injections from the correct scene-specific DI container.

The problem occurred only inside the Unity Editor due to how scene contexts were validated and referenced during play mode.